### PR TITLE
Diagnose cursor sticking issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "push:shopify:live": "shopify theme push --live --no-interactive"
   },
   "dependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
Add `push:shopify:live` npm script to enable non-interactive Shopify theme pushes.

This resolves the "stuck" cursor issue by providing a non-interactive command for pushing Shopify themes, as the original command was missing and would have prompted for input.

---
<a href="https://cursor.com/background-agent?bcId=bc-450c4a9e-e8b2-4ae6-b303-b73533330beb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-450c4a9e-e8b2-4ae6-b303-b73533330beb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

