### PR TITLE
Fix halloween script syntax error

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -27,6 +27,7 @@
       /* Higher specificity + !important so it beats any earlier .brand-line rules */
       html body header.header .brand-title .brand-line{
         color: var(--brand-teal) !important;
+      }
 
       /* Make sure pills stay red-glow too (even if --accent is pink) */
       html body header.header .nav a{
@@ -1255,11 +1256,6 @@
           });
         });
       }
-          
-        } catch (error) {
-          console.error('Error loading product:', error);
-          quickViewContent.innerHTML = '<div class="quick-view-loading">Error loading product</div>';
-        }
       
       // Add to cart from quick view
       window.addToCartFromQuickView = async function(variantId) {


### PR DESCRIPTION
Fix `SyntaxError` on cart page by removing a stray `catch` block and correct CSS parsing by adding a missing closing brace.

The `SyntaxError` was caused by an incorrectly placed `catch` block within an inline JavaScript quick-view function, leading to a parsing error on the cart page. The missing CSS brace was a simple syntax error in a `<style>` block.

---
<a href="https://cursor.com/background-agent?bcId=bc-17bdc5b7-b67c-448b-8471-1fa7a59129ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17bdc5b7-b67c-448b-8471-1fa7a59129ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

