### PR TITLE
Fix cart syntax error for halloween theme

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -1277,11 +1277,6 @@
           });
         });
       }
-          
-        } catch (error) {
-          console.error('Error loading product:', error);
-          quickViewContent.innerHTML = '<div class="quick-view-loading">Error loading product</div>';
-        }
       
       // Add to cart from quick view
       window.addToCartFromQuickView = async function(variantId) {


### PR DESCRIPTION
Remove a duplicate `catch` block in `layout/theme.liquid` to fix a `SyntaxError: missing ) after argument list` on the cart page.

---
<a href="https://cursor.com/background-agent?bcId=bc-6eded004-1103-4a9d-a18b-760ca62c132f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6eded004-1103-4a9d-a18b-760ca62c132f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

